### PR TITLE
Issue #9: Display seconds in hours, minutes, seconds for better readability. 

### DIFF
--- a/src/TimeUtil.js
+++ b/src/TimeUtil.js
@@ -1,0 +1,36 @@
+function calculateHoursMinutesSeconds(seconds) {
+  const hours = Math.floor(seconds / 3600);
+  seconds = seconds - hours * 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds = seconds - minutes * 60;
+  return {
+    hours,
+    minutes,
+    seconds,
+  };
+}
+  
+module.exports = function timeUntilLevelupString(seconds) {
+  const hms = calculateHoursMinutesSeconds(seconds);
+  let msg = "";
+  if (hms.hours) {
+    if (hms.hours === 1) {
+      msg += `${hms.hours} hour, `;
+    } else {
+      msg += `${hms.hours} hours, `;
+    }
+  }
+  if (hms.minutes || hms.hours) {
+    if (hms.minutes === 1) {
+      msg += `${hms.minutes} minute, `;      
+    } else {
+      msg += `${hms.minutes} minutes, `;
+    }
+  }
+  if (hms.seconds === 1) {
+    msg += `${hms.seconds} second`;
+  } else {
+    msg += `${hms.seconds} seconds`;
+  }  
+  return msg;
+}

--- a/src/idle.js
+++ b/src/idle.js
@@ -178,21 +178,38 @@ Idle.prototype.calculateTimeToLevel = function calculateTimeToLevel(level) {
   return Math.floor(600 * Math.pow(1.16, level-1));
 };
 
+function calculateHoursMinutesSeconds(seconds) {
+  const hours = Math.floor(seconds / 3600);
+  seconds = seconds - hours * 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds = seconds - minutes * 60;
+  return {
+    hours,
+    minutes,
+    seconds,
+  };
+}
+
+function timeUntilLevelupString(seconds) {
+  const hms = calculateHoursMinutesSeconds(seconds);
+  return `${hms.hours} hours, ${hms.minutes} minutes, ${hms.seconds} seconds`;
+}
+
 Idle.prototype.announceLevel = function announceLevel(player_data) {
   // announce the level up event in Slack
-  const message = `Player <@${player_data['user_id']}> has levelled up to *level ${player_data['level']}*! ${player_data['time_to_level']} seconds until the next level.`;
+  const message = `Player <@${player_data['user_id']}> has levelled up to *level ${player_data['level']}*! ${timeUntilLevelupString(player_data['time_to_level'])} until the next level.`;
   this.announce(player_data['team_id'], message);
 }
 
 Idle.prototype.announceRegistration = function announceRegistration(player_data) {
   // announce the level up event in Slack
-  const message = `Player <@${player_data['user_id']}> has started playing IdleRPG! Currently at *level ${player_data['level']}*, with ${player_data['time_to_level']} seconds until the next level.`;
+  const message = `Player <@${player_data['user_id']}> has started playing IdleRPG! Currently at *level ${player_data['level']}*, with ${timeUntilLevelupString(player_data['time_to_level'])} until the next level.`;
   this.announce(player_data['team_id'], message);
 }
 
 Idle.prototype.announcePenalty = function announcePenalty(event, penalty, player_data) {
   // announce the penalty event in Slack
-  const message = `Player <@${player_data['user_id']}> has been penalized by *${penalty} seconds* for *${event}* - must now wait ${player_data['time_to_level']} seconds until the next level.`;
+  const message = `Player <@${player_data['user_id']}> has been penalized by *${penalty} seconds* for *${event}* - must now wait ${timeUntilLevelupString(player_data['time_to_level'])} until the next level.`;
   this.announce(player_data['team_id'], message);
 }
 
@@ -227,13 +244,13 @@ Idle.prototype.handleUserRegistration = function handleUserRegistration(command)
       } else if (players !== null && players.includes(command.user_id) && data !== null) {
         // Is this player already registered?
         const player_data = JSON.parse(data);
-        const message = `You are currently level ${player_data['level']} and have ${player_data['time_to_level']} seconds left until you level up.`;
+        const message = `You are currently level ${player_data['level']} and have ${timeUntilLevelupString(player_data['time_to_level'])} left until you level up.`;
         winston.info(message);
         return resolve(message);
       } else if (players === null || !players.includes(command.user_id)) {
         // Register this player!
         player_data = this.initPlayer(command.team_id, command.user_id, command.user_name);
-        const message = `Welcome to IdleRPG! You are now level ${player_data['level']}, and have ${player_data['time_to_level']} seconds until you level up.`;
+        const message = `Welcome to IdleRPG! You are now level ${player_data['level']}, and have ${timeUntilLevelupString(player_data['time_to_level'])} until you level up.`;
         winston.info(message);
         this.announceRegistration(player_data);
         return resolve(message);

--- a/src/idle.js
+++ b/src/idle.js
@@ -3,6 +3,7 @@ const SlackWebClient = require('@slack/client').WebClient;
 
 const Clients = require('./clients');
 const Storage = require('./storage-redis');
+const timeUntilLevelupString = require('./TimeUtil');
 
 winston.level = 'debug';
 winston.remove(winston.transports.Console);
@@ -177,23 +178,6 @@ Idle.prototype.calculateTimeToLevel = function calculateTimeToLevel(level) {
   // #idlerpg
   return Math.floor(600 * Math.pow(1.16, level-1));
 };
-
-function calculateHoursMinutesSeconds(seconds) {
-  const hours = Math.floor(seconds / 3600);
-  seconds = seconds - hours * 3600;
-  const minutes = Math.floor(seconds / 60);
-  seconds = seconds - minutes * 60;
-  return {
-    hours,
-    minutes,
-    seconds,
-  };
-}
-
-function timeUntilLevelupString(seconds) {
-  const hms = calculateHoursMinutesSeconds(seconds);
-  return `${hms.hours} hours, ${hms.minutes} minutes, ${hms.seconds} seconds`;
-}
 
 Idle.prototype.announceLevel = function announceLevel(player_data) {
   // announce the level up event in Slack

--- a/test/TimeUtilTest.js
+++ b/test/TimeUtilTest.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const timeUntilLevelupString = require('../src/TimeUtil');
+
+describe("test seconds to hours/minutes/seconds", () => {  
+  assert.equal(timeUntilLevelupString(15711), "4 hours, 21 minutes, 51 seconds");
+
+  it("leaving out hours and minutes when they are 0", () => {
+    assert.equal(timeUntilLevelupString(125), "2 minutes, 5 seconds", "Shouldn't contain hours");
+    assert.equal(timeUntilLevelupString(7202), "2 hours, 0 minutes, 2 seconds", "Should contain 0 minutes if there are hours")
+    assert.equal(timeUntilLevelupString(45), "45 seconds", "Shouldn't contain hours or minutes");
+  });
+
+  it("tense correct with 1 hour/minute/second", () => {
+    assert.equal(timeUntilLevelupString(4911), "1 hour, 21 minutes, 51 seconds", "Hours should be singular tense");
+    assert.equal(timeUntilLevelupString(14511), "4 hours, 1 minute, 51 seconds", "Minutes should be singular tense");
+    assert.equal(timeUntilLevelupString(15661), "4 hours, 21 minutes, 1 second", "Seconds should be singular tense");
+    assert.equal(timeUntilLevelupString(3711), "1 hour, 1 minute, 51 seconds", "Hours/Minutes should be singular tense");
+    assert.equal(timeUntilLevelupString(4861), "1 hour, 21 minutes, 1 second", "Hours/Seconds should be singular tense");
+    assert.equal(timeUntilLevelupString(14461), "4 hours, 1 minute, 1 second", "Minutes/Seconds should be singular tense");
+    assert.equal(timeUntilLevelupString(3661), "1 hour, 1 minute, 1 second", "All should be singular tense");
+  });
+    
+  it("tense and leaving out hours and minutes at the same time", ()=> {
+    assert.equal(timeUntilLevelupString(65), "1 minute, 5 seconds", "Minutes should be singular tense");
+    assert.equal(timeUntilLevelupString(121), "2 minutes, 1 second", "Seconds should be singular tense");
+    assert.equal(timeUntilLevelupString(61), "1 minute, 1 second", "Minutes/Seconds should be singular tense");
+    assert.equal(timeUntilLevelupString(3605), "1 hour, 0 minutes, 5 seconds", "Hours should be singular tense")
+    assert.equal(timeUntilLevelupString(7201), "2 hours, 0 minutes, 1 second", "Seconds should be singular tense")
+    assert.equal(timeUntilLevelupString(3601), "1 hour, 0 minutes, 1 second", "Hours/Seconds should be singular tense")
+    assert.equal(timeUntilLevelupString(1), "1 second", "Seconds should be singular tense");
+  });
+});


### PR DESCRIPTION
I added 2 non-exported methods to aid in the conversion. All of the strings that specify time until next level use these new methods.

I couldn't test in Slack, because I was having trouble getting it set up. I have never worked with a slack bot before, and some quick Googling didn't lead me anywhere concrete. Also, 'npm start' didn't do anything.

I did some testing with the 2 new methods I created, and the insertion of the new method into the 5 template strings that deal with time_to_level.

Let me know if there are any problems, or you would like me to implement the solution in a different way.