### PR TITLE
Changed initial leveling time from 10 minutes to 5 minutes

### DIFF
--- a/src/idle.js
+++ b/src/idle.js
@@ -256,7 +256,7 @@ Idle.prototype.initPlayer = function initPlayer(team_id, player_id, display_name
 
 Idle.prototype.calculateTimeToLevel = function calculateTimeToLevel(level) {
   // #idlerpg
-  return Math.floor(600 * Math.pow(1.16, level-1));
+  return Math.floor(300 * Math.pow(1.16, level-1));
 };
 
 Idle.prototype.announceRegistration = function announceRegistration(player_data) {

--- a/test/IdleTest.js
+++ b/test/IdleTest.js
@@ -1,0 +1,14 @@
+const assert = require('assert'); 
+const Idle = require('../src/idle'); 
+const timeUntilLevelupString = require('../src/TimeUtil'); 
+ 
+describe("calculate time to level", () => { 
+  it("initial level up time is 5 minutes", () => { 
+    assert.equal(Idle.prototype.calculateTimeToLevel(1), 300); 
+    assert.equal(timeUntilLevelupString(300), "5 minutes, 0 seconds"); 
+  }) 
+  it("second level up time is slightly more than 5 minutes", () => { 
+    assert.equal(Idle.prototype.calculateTimeToLevel(2), 300 * 1.16); 
+    assert.equal(timeUntilLevelupString(300 * 1.16), "5 minutes, 48 seconds"); 
+  }) 
+});

--- a/test/idle-test.js
+++ b/test/idle-test.js
@@ -5,10 +5,8 @@ const timeUntilLevelupString = require('../src/TimeUtil');
 describe("calculate time to level", () => { 
   it("initial level up time is 5 minutes", () => { 
     assert.equal(Idle.prototype.calculateTimeToLevel(1), 300); 
-    assert.equal(timeUntilLevelupString(300), "5 minutes, 0 seconds"); 
   }) 
   it("second level up time is slightly more than 5 minutes", () => { 
     assert.equal(Idle.prototype.calculateTimeToLevel(2), 300 * 1.16); 
-    assert.equal(timeUntilLevelupString(300 * 1.16), "5 minutes, 48 seconds"); 
   }) 
 });


### PR DESCRIPTION
Updated Initial Level up time from 600 ( 10 minutes ) to 300 ( 5 minutes). Added tests that show the initial time starts at 5 minutes.